### PR TITLE
improve parsing of kernel versions

### DIFF
--- a/akms
+++ b/akms
@@ -225,13 +225,14 @@ statedir_to_triplet() {
 	echo "${statedir#$STATE_DIR}" | tr / ' '
 }
 
-# $1: kernel release (e.g. 5.10.53-0-lts)
+# $1: kernel release (e.g. 5.10.53-rc3-0-lts)
 # stdout: space-separated parts: pkgver pkgrel flavor
 split_kernel_ver() {
 	local kernel="$1"
-	local ver="${kernel%%-*}"
-	local rel="${kernel#*-}"; rel="${rel%%-*}"
-	local flavor="${kernel#$ver-$rel-}"
+	local flavor="${kernel##*-}"
+	local ver_rel="${kernel%-*}"
+	local ver="${ver_rel%-*}"
+	local rel="${ver_rel##*-}"
 
 	echo "$ver" "$rel" "$flavor"
 }


### PR DESCRIPTION
before:

```
~ $ split_kernel_ver 5.4.4-rc3-1-asahi
5.4.4 rc3 1-asahi
~ $ split_kernel_ver 5.4.4-1-edge
5.4.4 1 edge
~ $ split_kernel_ver 5.4.4-p2-4-custom
5.4.4 p2 4-custom
~ $ split_kernel_ver 5.4.1-0-lts
5.4.1 0 lts
```

after:

```
~/src/akms $ split_kernel_ver 5.4.4-rc3-1-asahi
5.4.4_rc3 1 asahi
~/src/akms $ split_kernel_ver 5.4.4-1-edge
5.4.4 1 edge
~/src/akms $ split_kernel_ver 5.4.4-p2-4-custom
5.4.4_p2 4 custom
~/src/akms $ split_kernel_ver 5.4.1-0-lts
5.4.1 0 lts
```

i'm not sure if the - -> _ is wanted or not, but the rest should be correct