### PR TITLE
Copy module source to build dir

### DIFF
--- a/akms
+++ b/akms
@@ -578,7 +578,8 @@ build_module() {
 	[ -d "$TEMP_DIR/overlay" ] && build_root="$TEMP_DIR/overlay"
 
 	rm -Rf "$builddir"
-	install -d -o "$BUILD_USER" "$builddir" || return 1
+	cp -a "$srcdir/" "$builddir" || return 1
+	chown -R "$BUILD_USER" "$builddir" || return 1
 
 	runas "$BUILD_USER" \
 		--sandbox "${build_root:-/}" \

--- a/akms-build
+++ b/akms-build
@@ -13,7 +13,7 @@ cd "$builddir"
 
 default_build() {
 	touch "$builddir"/Makefile
-	make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" src="$srcdir" modules
+	make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" modules
 }
 
 if [ $LOG_LEVEL = warn ]; then


### PR DESCRIPTION
Changes to the kernel Makefiles have broken the hack used to avoid doing this

Ref: https://gitlab.alpinelinux.org/alpine/aports/-/issues/16718