### PR TITLE
Copy module sources to builddir and don't set src= for make command

### DIFF
--- a/AKMBUILD.5.adoc
+++ b/AKMBUILD.5.adoc
@@ -84,7 +84,7 @@ This directory is read-only.
 
 *builddir*::
 Location of the directory where the module should be built.
-It is initially empty and it is the only writtable directory for building the module.
+It is initialized with a copy of the *srcdir* and it is the only writtable directory for building the module.
 
 *MAKEFLAGS*::
 Flags to give to make(1) to build the module.
@@ -96,13 +96,13 @@ The default value of this variable can be specified in {akms-conf}.
 The following functions MAY be overridden by the author of the *AKMBUILD* file.
 
 *build*::
-Builds the kernel module(s) in the *builddir* from the source files located in the *srcdir* directory.
+Builds the kernel module(s) in the *builddir*.
 +
 The default implementation calls function *default_build*:
 +
 [source, sh]
 touch "$builddir"/Makefile
-make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" src="$srcdir" modules
+make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" modules
 
 
 == EXAMPLES
@@ -116,7 +116,7 @@ built_modules='rtw89core.ko rtw89pci.ko'
 
 build() {
     touch "$builddir"/Makefile
-    make $MAKEFLAGS -C "$kernel_srcdir" M="$builddir" src="$srcdir" modules
+    make $MAKEFLAGS -C "$kernel_srcdir" M="$builddir" modules
 }
 ----
 

--- a/AKMBUILD.example
+++ b/AKMBUILD.example
@@ -15,5 +15,5 @@ built_modules='rtw89core.ko rtw89pci.ko'
 # A custom build function may be defined. The following is the default_build.
 build() {
 	touch "$builddir"/Makefile
-	make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" src="$srcdir" modules
+	make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" modules
 }

--- a/akms
+++ b/akms
@@ -578,7 +578,10 @@ build_module() {
 	[ -d "$TEMP_DIR/overlay" ] && build_root="$TEMP_DIR/overlay"
 
 	rm -Rf "$builddir"
-	install -d -o "$BUILD_USER" "$builddir" || return 1
+	# NOTE: The module sources must be available in the builddir, see
+	#  https://gitlab.alpinelinux.org/alpine/aports/-/issues/16718.
+	cp -a "$srcdir" "$builddir" || return 1
+	chown -R "$BUILD_USER" "$builddir" || return 1
 
 	runas "$BUILD_USER" \
 		--sandbox "${build_root:-/}" \

--- a/akms-build
+++ b/akms-build
@@ -9,11 +9,11 @@ readonly builddir kernel_srcdir kernel_ver LOG_LEVEL
 
 cd "$builddir"
 
-. "$srcdir"/AKMBUILD
+. AKMBUILD
 
 default_build() {
 	touch "$builddir"/Makefile
-	make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" src="$srcdir" modules
+	make ${MAKEFLAGS:-} -C "$kernel_srcdir" M="$builddir" modules
 }
 
 if [ $LOG_LEVEL = warn ]; then


### PR DESCRIPTION
Now we set the `M` variable with the path to the empty and writable `builddir` directory where all build files (*.o, *.ko, ...) are created, and the `src` variable with the path to the readonly `srcdir` with the module source files.

Unfortunately, this doesn't work anymore due to the following changes in the recent kernel make files:

- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=9a0ebe5011f49e932bb0a2cea2034fd65e6e567e
- https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=b1992c3772e69a6fd0e3fc81cd4d2820c8b6eca0

So we have to copy the module sources from `srcdir` to `builddir`.

See: https://gitlab.alpinelinux.org/alpine/aports/-/issues/16718