### PR TITLE
Add option to disable sandbox

### DIFF
--- a/akms
+++ b/akms
@@ -64,6 +64,11 @@
 #          created on top of /, or on the host system. Default is to use overlay
 #          unless disabled in /etc/akms.conf.
 #
+#        --[no-]sandbox
+#          Whether to install build dependencies and build modules in a sandbox
+#          using bubblewrap. Default is to use sandbox unless disabled in
+#          /etc/akms.conf.
+#
 #        --skip-cleanup
 #          Don't unmount and delete root overlay used for building and don't
 #          uninstall build dependencies.
@@ -581,6 +586,9 @@ build_module() {
 	local build_root=
 	[ -d "$TEMP_DIR/overlay" ] && build_root="$TEMP_DIR/overlay"
 
+	local runas_sandbox=
+	$OPT_SANDBOX && runas_sandbox=true
+
 	rm -Rf "$builddir"
 	# NOTE: The module sources must be available in the builddir, see
 	#  https://gitlab.alpinelinux.org/alpine/aports/-/issues/16718.
@@ -588,8 +596,7 @@ build_module() {
 	chown -R "$BUILD_USER" "$builddir" || return 1
 
 	runas "$BUILD_USER" \
-		--sandbox "${build_root:-/}" \
-		--bind "$builddir" "$builddir" \
+		${runas_sandbox:+--sandbox "${build_root:-/}" --bind "$builddir" "$builddir"} \
 		srcdir="$srcdir" \
 		builddir="$builddir" \
 		kernel_ver="$kernel" \
@@ -857,13 +864,14 @@ OPT_KEEP_UNINSTALLED=$(to_bool "${keep_uninstalled:-false}")
 OPT_KERNEL=
 OPT_LOGLEVEL=${log_level:-info}
 OPT_OVERLAY=$(to_bool "${use_overlayfs:-true}")
+OPT_SANDBOX=$(to_bool "${use_sandbox:-true}")
 OPT_REBUILD=false
 OPT_STATE='all'
 OPT_SKIP_CLEANUP=false
 
 opts=$(getopt -n $PROGNAME \
 	-o fKk:qrs:vVh \
-	-l force,keep,no-keep,kernel:,overlay,no-overlay,quiet,rebuild,skip-cleanup,state:,verbose,version,help \
+	-l force,keep,no-keep,kernel:,overlay,no-overlay,sandbox,no-sandbox,quiet,rebuild,skip-cleanup,state:,verbose,version,help \
 	-- "$@") || exit 1
 eval set -- "$opts"
 
@@ -877,6 +885,8 @@ while [ $# -gt 0 ]; do
 		-q | --quiet) OPT_LOGLEVEL='warn';;
 		     --overlay) OPT_OVERLAY=true;;
 		     --no-overlay) OPT_OVERLAY=false;;
+		     --sandbox) OPT_SANDBOX=true;;
+		     --no-sandbox) OPT_SANDBOX=false;;
 		-r | --rebuild) OPT_REBUILD=true;;
 		     --skip-cleanup) OPT_SKIP_CLEANUP=true;;
 		-s | --state) OPT_STATE=$2; n=2;;
@@ -895,7 +905,7 @@ fi
 setup_logger "$OPT_LOGLEVEL"
 
 readonly ACTION OPT_FORCE OPT_KEEP_UNINSTALLED OPT_KERNEL OPT_LOGLEVEL
-readonly OPT_OVERLAY OPT_REBUILD OPT_STATE OPT_SKIP_CLEANUP
+readonly OPT_OVERLAY OPT_SANDBOX OPT_REBUILD OPT_STATE OPT_SKIP_CLEANUP
 
 umask 022
 

--- a/akms
+++ b/akms
@@ -124,7 +124,7 @@ MAKEFLAGS="-j$(nproc)"
 
 readonly BUILD_USER=${build_user:-akms}
 readonly BWRAP_OPTS=${bubblewrap_opts:-}
-readonly MAKEDEPENDS=${makedepends:-build-base}
+readonly MAKEDEPENDS=${makedepends:-}
 readonly MAKEFLAGS
 readonly MODULES_DEST_PATH=${modules_dest_path:-/kernel/extra/akms}
 readonly MODULES_SRC_DIR=${modules_srcdir:-/usr/src}
@@ -524,6 +524,11 @@ install_makedepends() {
 	if [ -d "$TEMP_DIR"/overlay ]; then
 		build_root="$TEMP_DIR/overlay"
 		apk_opts="--root $build_root"
+	fi
+
+	# if any of these files are missing, it means `build-base` needs installing
+	if [ ! -f "/usr/bin/readelf" ] || [ ! -f "/usr/bin/file" ] || [ ! -f "/usr/bin/gcc" ] || [ ! -f "/usr/bin/g++" ] || [ ! -f "/usr/bin/make" ] || [ ! -f "/usr/bin/patch" ]; then
+		makedepends="$makedepends build-base"
 	fi
 
 	# If all $makedepends are installed, empty $makedepends.

--- a/akms.8.adoc
+++ b/akms.8.adoc
@@ -138,6 +138,10 @@ Rebuild (and install) the module even if it has been already built.
 Whether to install the build dependencies into the root overlay created on top of `/`, or on the host system.
 This option overrides parameter *use_overlayfs* specified in {akms-conf} (enabled by default).
 
+*--[no-]sandbox*::
+Whether to install build dependencies and build modules in a sandbox using bubblewrap. Default is to use sandbox unless disabled in /etc/akms.conf.
+This option overrides parameter *use_sandbox* specified in {akms-conf} (enabled by default)
+
 *--skip-cleanup*::
 Do not unmount and delete the root overlay used for building and do not uninstall the build dependencies.
 

--- a/akms.conf.5.adoc
+++ b/akms.conf.5.adoc
@@ -114,6 +114,9 @@ Specifies whether to install the module`'s build dependencies into a disposable 
 +
 The default value is `"yes"`.
 
+*use_sandbox*::
+Specifies whether to install the module`'s build dependencies into a sanbox or directly on the host system.
+
 *MAKEFLAGS*::
 Specifies the flags to be passed to `make(1)` to build a kernel module.
 +

--- a/akms.kernel-hook
+++ b/akms.kernel-hook
@@ -17,6 +17,12 @@ if [ "$OLD_VERSION" ]; then
 	fi
 fi
 if [ "$NEW_VERSION" ]; then
-	akms install -k "$NEW_VERSION-$FLAVOR" all || rc=1
+	if [ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]; then
+		echo ">>> AKMS is running in chroot environment, disabling overlay and sandboxing"
+		echo ">>> Please make sure module build dependencies are already installed"
+		akms install --no-overlay --no-sandbox -k $NEW_VERSION-$FLAVOR all || rc=1
+	else
+		akms install -k $NEW_VERSION-$FLAVOR all || rc=1
+	fi
 fi
 exit $rc


### PR DESCRIPTION
Fixes https://github.com/jirutka/akms/issues/18

When building AKMS packages in chroot or LXC, sandboxing isn't always possible. This adds `use_sandbox` boolean and `--[no]-sandbox` option to AKMS to disable sandboxing.